### PR TITLE
remove uppercase from returnMetabolome

### DIFF
--- a/R/feature_processing.R
+++ b/R/feature_processing.R
@@ -352,7 +352,7 @@ getMultiOmicsFeatures <- function(dbs = c("all"), layer = c("all"),
 
   returnTranscriptome <- toupper(returnTranscriptome)
   returnProteome <- toupper(returnProteome)
-  returnMetabolome <- toupper(returnMetabolome)
+  # returnMetabolome <- toupper(returnMetabolome)
 
   ## check for the correct transcriptome mapping format
   supportedIDs <- c("SYMBOL", "ENTREZID", "UNIPROT", "ENSEMBL", "REFSEQ")


### PR DESCRIPTION
Uppercasing returnMetabolome does not handle ChEBI and Drugbank correctly. Commenting out.